### PR TITLE
ci: fix test-bot failures and bump actions to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,17 @@ env:
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_NO_ENV_HINTS: 1
+  # Tap trust enforcement (Homebrew/brew#22470) makes `brew doctor` fail in
+  # `brew test-bot` for the tap under test. Opt out to keep CI green.
+  # See https://github.com/Homebrew/brew/issues/22494
+  HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
 
 jobs:
   test-bot:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14]
+        os: [ubuntu-24.04, macos-14]
     runs-on: ${{ matrix.os }}
 
     permissions:
@@ -46,7 +50,7 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@59e6b20d96df1a3c9ccb0aa402676e01a4cc6ff3 # main
 
       - name: Cache Homebrew Bundler RubyGems
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}


### PR DESCRIPTION
Fix the persistent CI failures in `brew test-bot --only-setup` where
`brew doctor` exited non-zero:

- Tap trust enforcement (Homebrew/brew#22470) makes `brew doctor` flag the
  tap under test as untrusted and fail in test-bot. Opt out via
  HOMEBREW_NO_REQUIRE_TAP_TRUST=1 (Homebrew/brew#22494).
- Bump ubuntu-22.04 -> ubuntu-24.04 so glibc is 2.39 (Tier 1) instead of
  the too-old 2.35 (Tier 2) warning.

Also update actions/cache 5.0.5 -> 6.0.0 (latest); all other pinned
actions are already at their latest releases.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019iGu29tGmjqR9aJTVYcDDx