### PR TITLE
feat(site): group formula versions under their main formula

### DIFF
--- a/scripts/build_site.rb
+++ b/scripts/build_site.rb
@@ -9,6 +9,7 @@ require "time"
 require "terser"
 require "cssminify2"
 require_relative "array_extensions"
+require_relative "string_extensions"
 require_relative "time_formatter"
 require_relative "asset_processor"
 
@@ -96,8 +97,8 @@ class SiteBuilder
   # formula. Templates keep reading @data["formulae"]/["formulae_count"], so only
   # this transform and the versions section on the formula page need to know.
   def group_formulae
-    all = Array(@data["formulae"]).select { |f| f.is_a?(Hash) }
-    mains, versioned = all.partition { |f| !f["name"].to_s.include?("@") }
+    all = Array(@data["formulae"]).grep(Hash)
+    mains, versioned = all.partition { |f| f["name"].to_s.exclude?("@") }
     by_base = versioned.group_by { |f| f["name"].to_s.split("@", 2).first }
 
     mains.each { |m| m["versions"] = sort_versions(by_base.delete(m["name"].to_s) || []) }
@@ -115,11 +116,9 @@ class SiteBuilder
   # ponytail: Gem::Version handles both semver and calver; unparseable → 0.
   def sort_versions(list)
     list.sort_by do |f|
-      begin
-        Gem::Version.new(f["version"].to_s)
-      rescue ArgumentError
-        Gem::Version.new("0")
-      end
+      Gem::Version.new(f["version"].to_s)
+    rescue ArgumentError
+      Gem::Version.new("0")
     end.reverse
   end
 

--- a/scripts/build_site.rb
+++ b/scripts/build_site.rb
@@ -88,6 +88,39 @@ class SiteBuilder
   def load_data
     formulae_file = File.join(DATA_DIR, "formulae.json")
     @data = File.exist?(formulae_file) ? JSON.parse(File.read(formulae_file)) : default_data
+    group_formulae
+  end
+
+  # Collapse the flat formulae list (main + "name@version" entries) so the site
+  # shows one card/page per tool, with every version listed under its main
+  # formula. Templates keep reading @data["formulae"]/["formulae_count"], so only
+  # this transform and the versions section on the formula page need to know.
+  def group_formulae
+    all = Array(@data["formulae"]).select { |f| f.is_a?(Hash) }
+    mains, versioned = all.partition { |f| !f["name"].to_s.include?("@") }
+    by_base = versioned.group_by { |f| f["name"].to_s.split("@", 2).first }
+
+    mains.each { |m| m["versions"] = sort_versions(by_base.delete(m["name"].to_s) || []) }
+
+    # Versioned formulae with no plain main: synthesize a main from the newest.
+    by_base.each do |base, vers|
+      sorted = sort_versions(vers)
+      mains << sorted.first.merge("name" => base, "versions" => sorted)
+    end
+
+    @data["formulae"] = mains.sort_by { |m| m["name"].to_s.downcase }
+    @data["formulae_count"] = mains.length
+  end
+
+  # ponytail: Gem::Version handles both semver and calver; unparseable → 0.
+  def sort_versions(list)
+    list.sort_by do |f|
+      begin
+        Gem::Version.new(f["version"].to_s)
+      rescue ArgumentError
+        Gem::Version.new("0")
+      end
+    end.reverse
   end
 
   def generate_assets

--- a/scripts/string_extensions.rb
+++ b/scripts/string_extensions.rb
@@ -7,4 +7,8 @@ class String
     # Polyfill implementation to avoid external dependencies
     nil? || empty? # rubocop:disable Homebrew/Blank, Lint/RedundantCopDisableDirective
   end
+
+  def exclude?(item)
+    !include?(item)
+  end
 end

--- a/theme/formula.html.erb
+++ b/theme/formula.html.erb
@@ -102,6 +102,26 @@
           </table>
         </div>
       </section>
+
+      <% versions = Array(@formula['versions']).select { |v| v.is_a?(Hash) } %>
+      <% if versions.any? %>
+      <section class="space-y-4">
+        <h2 class="text-2xl font-semibold tracking-tight px-8 h-10">Versions</h2>
+        <div class="space-y-4 px-8">
+          <% versions.each do |v| %>
+            <div class="space-y-2">
+              <div class="flex items-center gap-3">
+                <span class="badge inline-flex items-center rounded-full bg-emerald-500 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white dark:bg-emerald-400">v<%= h(v['version'].to_s) %></span>
+                <% if v['url'] %>
+                  <a href="<%= h(v['url'].to_s) %>" target="_blank" class="text-sm text-sky-600 transition hover:text-sky-500 dark:text-sky-400 dark:hover:text-sky-300">Download ↗</a>
+                <% end %>
+              </div>
+              <%= render_partial('command_input', command: "brew install #{h("#{tap_name}/#{v['name']}")}", size: 'sm', label: 'CLI') %>
+            </div>
+          <% end %>
+        </div>
+      </section>
+      <% end %>
     </main>
   </div>
 


### PR DESCRIPTION
## What

The formula sync generates one formula per release version (`name@version`), which flooded `index.html` and `formulae.html` with a card per version. This groups them so the site shows **one entry per tool**, with every version listed **under the main formula page**.

## Changes

- **`scripts/build_site.rb`** — new `group_formulae` step collapses the flat `name` + `name@version` list into one entry per tool, attaching a `versions` array sorted newest-first via `Gem::Version` (handles both semver and calver). Templates keep reading `@data["formulae"]`/`["formulae_count"]`, so index/formulae pages need no change.
- **`theme/formula.html.erb`** — added a "Versions" section listing each pinned version with a copy-paste `brew install …@x.y.z` command and download link.

## Result (verified via real build)

- `index.html` / `formulae.html`: 4 main formulae instead of 15 rows.
- Only main-formula pages generated (`a.html`, `gh-action-readme.html`, …) — no `@version` pages.
- `gh-action-readme.html` lists all 4 versions; `gh-calver.html` orders `2026.03.4 → 0.1.0` correctly.

`formulae.json` is left as the flat source of truth — grouping is a view concern done at render time.