### PR TITLE
chore(renovate): ignore versioned formula files

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>ivuorinen/renovate-config"]
+  "extends": ["local>ivuorinen/renovate-config"],
+  "packageRules": [
+    {
+      "matchFileNames": ["Formula/**/*@*.rb"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Renovate keeps trying to bump the pinned per-version formulae under `Formula/**/*@*.rb`. This adds a `packageRules` entry that disables Renovate for those versioned files while leaving the main formulae updatable.

Chose `matchFileNames` + `enabled: false` over `ignorePaths` so it stays additive and doesn't clobber the shared preset's defaults.