### PR TITLE
feat: three-way theme toggle + brew-free RuboCop linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,38 @@
+# Homebrew's own RuboCop config, vendored + a thin local overlay.
+#
+# .rubocop_homebrew.yml is copied verbatim from Homebrew/homebrew-core:
+#   curl -fsSL https://raw.githubusercontent.com/Homebrew/homebrew-core/main/.rubocop.yml \
+#     -o .rubocop_homebrew.yml
+# Re-run that to refresh it. It is pure standard-cop config (Layout/Lint/Naming/
+# Style), so it runs with plain `rubocop` — no brew required.
+#
+# NOT a full replica of `brew style`: that layers this on top of brew's internal
+# base config, which disables Metrics and loads the FormulaAudit/Cask/Homebrew
+# cops that only exist inside brew. CI (`brew test-bot --only-tap-syntax`) remains
+# the authority on the audit cops; the overlay below just replays the Metrics
+# disable so local lint is not stricter than CI.
+inherit_from: .rubocop_homebrew.yml
+
+inherit_mode:
+  merge:
+    - Exclude
+
+AllCops:
+  # Honor the Gemfile floor (ruby ">= 3.0.0"); the vendored file pins 4.0.
+  TargetRubyVersion: "3.0"
+  # The vendored config sets Include to ["**/*.rbi"] (it assumes brew's base
+  # config supplies the default **/*.rb). Restore it so our .rb files are linted.
+  Include:
+    - "**/*.rb"
+    - "Gemfile"
+  Exclude:
+    - "vendor/**/*"
+    - "site/**/*"
+    - "_site/**/*"
+    - "node_modules/**/*"
+
+# The vendored homebrew-core file configures no Metrics (that disable lives in
+# brew's internal base config). Replicate it so local lint is not stricter than
+# CI. Re-enable if you want tighter checks on scripts/.
+Metrics:
+  Enabled: false

--- a/.rubocop_homebrew.yml
+++ b/.rubocop_homebrew.yml
@@ -1,0 +1,244 @@
+# This file is synced from `Homebrew/brew` by the `.github` repository, do not modify it directly.
+---
+AllCops:
+  TargetRubyVersion: 4.0
+  NewCops: enable
+  Include:
+  - "**/*.rbi"
+  Exclude:
+  - Homebrew/sorbet/rbi/{annotations,dsl,gems}/**/*.rbi
+  - Homebrew/sorbet/rbi/parser*.rbi
+  - Homebrew/bin/*
+  - Homebrew/vendor/**/*
+  - Taps/*/*/vendor/**/*
+  - "**/.github/copilot-instructions.md"
+  - "**/vendor/**/*"
+  SuggestExtensions:
+    rubocop-minitest: false
+Layout/ArgumentAlignment:
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/Formula/**/*.rb"
+  - "**/Formula/**/*.rb"
+Layout/CaseIndentation:
+  EnforcedStyle: end
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: start_of_line
+Layout/HashAlignment:
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
+Layout/LeadingCommentSpace:
+  Exclude:
+  - Taps/*/*/cmd/*.rb
+Layout/LineLength:
+  Max: 118
+  AllowedPatterns:
+  - "#: "
+  - ' url "'
+  - ' mirror "'
+  - " plist_options "
+  - ' executable: "'
+  - ' font "'
+  - ' homepage "'
+  - ' name "'
+  - ' pkg "'
+  - ' pkgutil: "'
+  - "    sha256 cellar: "
+  - "    sha256  "
+  - "#{language}"
+  - "#{version."
+  - ' "/Library/Application Support/'
+  - "\"/Library/Caches/"
+  - "\"/Library/PreferencePanes/"
+  - ' "~/Library/Application Support/'
+  - "\"~/Library/Caches/"
+  - "\"~/Library/Containers"
+  - "\"~/Application Support"
+  - " was verified as official when first introduced to the cask"
+Layout/SpaceAroundOperators:
+  Enabled: false
+Layout/SpaceBeforeBrackets:
+  Exclude:
+  - "**/*_spec.rb"
+  - Taps/*/*/*.rb
+  - "/**/{Formula,Casks}/**/*.rb"
+  - "**/{Formula,Casks}/**/*.rb"
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+Lint/DuplicateBranch:
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/{Formula,Casks}/**/*.rb"
+  - "**/{Formula,Casks}/**/*.rb"
+Lint/ParenthesesAsGroupedExpression:
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/Formula/**/*.rb"
+  - "**/Formula/**/*.rb"
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: true
+Metrics:
+  Enabled: false
+Naming/BlockForwarding:
+  Enabled: false
+Naming/FileName:
+  Regex: !ruby/regexp /^[\w\@\-\+\.]+(\.rb)?$/
+Naming/HeredocDelimiterNaming:
+  ForbiddenDelimiters:
+  - END, EOD, EOF
+Naming/InclusiveLanguage:
+  CheckStrings: true
+  FlaggedTerms:
+    slave:
+      AllowedRegex:
+      - gitslave
+      - log_slave
+      - ssdb_slave
+      - var_slave
+      - patches/13_fix_scope_for_show_slave_status_data.patch
+Naming/MethodName:
+  AllowedPatterns:
+  - "\\A(fetch_)?HEAD\\?\\Z"
+Naming/MethodParameterName:
+  inherit_mode:
+    merge:
+    - AllowedNames
+Naming/PredicateMethod:
+  AllowBangMethods: true
+Naming/VariableNumber:
+  Enabled: false
+Style/AndOr:
+  EnforcedStyle: always
+Style/ArgumentsForwarding:
+  Enabled: false
+Style/ArrayIntersect:
+  Enabled: false
+Style/AutoResourceCleanup:
+  Enabled: true
+Style/BarePercentLiterals:
+  EnforcedStyle: percent_q
+Style/BlockDelimiters:
+  BracesRequiredMethods:
+  - sig
+Style/ClassAndModuleChildren:
+  Exclude:
+  - "**/*.rbi"
+Style/CollectionMethods:
+  Enabled: true
+Style/DisableCopsWithinSourceCodeDirective:
+  Enabled: true
+  Include:
+  - Taps/*/*/*.rb
+  - "/**/{Formula,Casks}/**/*.rb"
+  - "**/{Formula,Casks}/**/*.rb"
+Style/Documentation:
+  Exclude:
+  - Taps/**/*
+  - "/**/{Formula,Casks}/**/*.rb"
+  - "**/{Formula,Casks}/**/*.rb"
+  - "**/*.rbi"
+Style/EmptyMethod:
+  Exclude:
+  - "**/*.rbi"
+Style/FetchEnvVar:
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/Formula/**/*.rb"
+  - "**/Formula/**/*.rb"
+Style/OneClassPerFile:
+  Exclude:
+  - "**/*.rbi"
+  - Taps/*/*/*.rb
+  - "/**/Abstract/**/*.rb"
+  - "**/Abstract/**/*.rb"
+  - "/**/Formula/**/*.rb"
+  - "**/Formula/**/*.rb"
+  - "/**/developer/bin/*"
+  - "**/developer/bin/*"
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/{Formula,Casks}/**/*.rb"
+  - "**/{Formula,Casks}/**/*.rb"
+  - Homebrew/test/**/Casks/**/*.rb
+  - "**/*.rbi"
+  - "**/Brewfile"
+Style/GuardClause:
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/{Formula,Casks}/**/*.rb"
+  - "**/{Formula,Casks}/**/*.rb"
+Style/HashAsLastArrayItem:
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/Formula/**/*.rb"
+  - "**/Formula/**/*.rb"
+Style/InverseMethods:
+  InverseMethods:
+    :blank?: :present?
+Style/InvertibleUnlessCondition:
+  Enabled: true
+  InverseMethods:
+    :==: :!=
+    :zero?:
+    :blank?: :present?
+Style/ItBlockParameter:
+  EnforcedStyle: only_numbered_parameters
+Style/MutableConstant:
+  EnforcedStyle: strict
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_only
+Style/NumericLiterals:
+  MinDigits: 11
+  Strict: true
+Style/OpenStructUse:
+  Exclude:
+  - Taps/**/*
+Style/OptionalBooleanParameter:
+  AllowedMethods:
+  - respond_to?
+  - respond_to_missing?
+Style/RescueStandardError:
+  EnforcedStyle: implicit
+Style/ReturnNil:
+  Enabled: true
+Style/StderrPuts:
+  Enabled: false
+Style/StringConcatenation:
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/{Formula,Casks}/**/*.rb"
+  - "**/{Formula,Casks}/**/*.rb"
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+Style/StringMethods:
+  Enabled: true
+Style/SuperWithArgsParentheses:
+  Enabled: false
+Style/SymbolArray:
+  EnforcedStyle: brackets
+Style/TernaryParentheses:
+  EnforcedStyle: require_parentheses_when_complex
+Style/TopLevelMethodDefinition:
+  Enabled: true
+  Exclude:
+  - Taps/**/*
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+Style/UnlessLogicalOperators:
+  Enabled: true
+  EnforcedStyle: forbid_logical_operators
+Style/WordArray:
+  MinSize: 4
+

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,6 @@ gem "terser", "~> 1.2"
 
 # dev dependencies
 group :development do
+  gem "rubocop", "~> 1.81", require: false
   gem "webrick", "~> 1.9"
 end

--- a/Makefile
+++ b/Makefile
@@ -197,9 +197,18 @@ tap-install: ## Install this tap locally for testing
 	@echo "🍺 Installing tap locally..."
 	@brew tap $$(pwd)
 
-lint: ## Lint all Ruby scripts
-	@echo "🔍 Linting Ruby scripts..."
-	@brew style --fix --reset-cache .
+lint: ## Lint Ruby (RuboCop, no brew needed). Formula audit still runs in CI via brew.
+	@echo "🔍 Linting Ruby with RuboCop..."
+	@bundle exec rubocop
+
+lint-fix: ## Auto-correct safe RuboCop offenses
+	@echo "🔧 Auto-correcting RuboCop offenses..."
+	@bundle exec rubocop -A
+
+lint-update-config: ## Refresh vendored Homebrew RuboCop config from homebrew-core
+	@echo "⬇️  Updating .rubocop_homebrew.yml from Homebrew/homebrew-core..."
+	@curl -fsSL https://raw.githubusercontent.com/Homebrew/homebrew-core/main/.rubocop.yml -o .rubocop_homebrew.yml
+	@echo "✅ Updated. Run 'make lint' to check for new offenses."
 
 formula-new: ## Create a new formula template (usage: make formula-new NAME=myformula)
 	@if [ -z "$(NAME)" ]; then \

--- a/theme/_head.html.erb
+++ b/theme/_head.html.erb
@@ -17,7 +17,8 @@
       try {
         const stored = window.localStorage.getItem("theme");
         const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-        const theme = stored || (prefersDark ? "dark" : "light");
+        const mode = (stored === "light" || stored === "dark") ? stored : "auto";
+        const theme = mode === "auto" ? (prefersDark ? "dark" : "light") : mode;
         document.documentElement.classList.toggle("dark", theme === "dark");
         document.documentElement.classList.toggle("light", theme !== "dark");
         document.documentElement.setAttribute("data-theme", theme);

--- a/theme/_header.html.erb
+++ b/theme/_header.html.erb
@@ -4,12 +4,9 @@
   </nav>
 
   <div class="header flex flex-col gap-6 rounded-3xl border border-slate-200 bg-white/80 p-8 shadow-sm ring-1 ring-black/5 backdrop-blur dark:border-slate-700 dark:bg-slate-900/80 dark:ring-white/10">
-    <div class="flex items-start justify-between gap-4">
-      <div class="space-y-2">
-        <h1 class="text-3xl font-bold tracking-tight md:text-4xl"><%= h(tap_name) %></h1>
-        <p class="max-w-3xl text-base text-slate-600 dark:text-slate-300"><%= h(description) %></p>
-      </div>
-      <button class="theme-toggle inline-flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full border border-slate-300 bg-white/80 text-xl text-slate-600 shadow-sm transition hover:bg-slate-100 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:border-slate-600 dark:bg-slate-900/70 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white" aria-label="Toggle dark mode" tabindex="0">🌙</button>
+    <div class="space-y-2">
+      <h1 class="text-3xl font-bold tracking-tight md:text-4xl"><%= h(tap_name) %></h1>
+      <p class="max-w-3xl text-base text-slate-600 dark:text-slate-300"><%= h(description) %></p>
     </div>
   </div>
 </header>

--- a/theme/_nav.html.erb
+++ b/theme/_nav.html.erb
@@ -10,4 +10,8 @@ end %>
   <% formulae_classes = [nav_base, (active_tab == :formulae ? nav_active : nil)].compact.join(' ') %>
   <a href="<%= h(href.call('index.html')) %>" class="<%= home_classes %>">Home</a>
   <a href="<%= h(href.call('formulae.html')) %>" class="<%= formulae_classes %>">All Formulae</a>
+  <button class="theme-toggle ml-auto inline-flex h-9 items-center gap-2 rounded-full border border-slate-300 bg-white/80 px-3 text-slate-600 shadow-sm transition hover:bg-slate-100 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:border-slate-600 dark:bg-slate-900/70 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white" aria-label="Theme: Auto" tabindex="0">
+    <span class="theme-toggle-icon" aria-hidden="true">🌗</span>
+    <span class="theme-toggle-label">Auto</span>
+  </button>
 </nav>

--- a/theme/main.js
+++ b/theme/main.js
@@ -1,71 +1,75 @@
-// Dark mode toggle functionality
+// Theme toggle: cycles auto -> light -> dark -> auto. Auto follows the OS.
 (() => {
   const STORAGE_KEY = "theme";
+  const ORDER = ["auto", "light", "dark"];
+  const ICONS = { auto: "🌗", light: "☀️", dark: "🌙" };
+  const LABELS = { auto: "Auto", light: "Light", dark: "Dark" };
 
-  function getStoredTheme() {
+  function getMode() {
+    let mode = null;
     try {
-      return localStorage.getItem(STORAGE_KEY);
+      mode = localStorage.getItem(STORAGE_KEY);
     } catch {
-      return null;
+      // Ignore storage failures
     }
+    return ORDER.includes(mode) ? mode : "auto";
   }
 
-  function setStoredTheme(theme) {
+  function setMode(mode) {
     try {
-      localStorage.setItem(STORAGE_KEY, theme);
+      localStorage.setItem(STORAGE_KEY, mode);
     } catch {
       // Ignore storage failures
     }
   }
 
-  function getSystemTheme() {
+  function resolve(mode) {
+    if (mode !== "auto") return mode;
     return window.matchMedia?.("(prefers-color-scheme: dark)").matches
       ? "dark"
       : "light";
   }
 
-  function getCurrentTheme() {
-    return getStoredTheme() || getSystemTheme() || "light";
-  }
+  function apply(mode) {
+    const theme = resolve(mode);
+    const root = document.documentElement;
+    root.classList.toggle("dark", theme === "dark");
+    root.classList.toggle("light", theme !== "dark");
+    root.setAttribute("data-theme", theme);
 
-  function applyTheme(theme) {
-    document.documentElement.classList.toggle("dark", theme === "dark");
     const toggle = document.querySelector(".theme-toggle");
     if (toggle) {
-      toggle.innerHTML = theme === "dark" ? "☀️" : "🌙";
-      toggle.setAttribute(
-        "aria-label",
-        theme === "dark" ? "Switch to light mode" : "Switch to dark mode",
-      );
+      const icon = toggle.querySelector(".theme-toggle-icon");
+      const label = toggle.querySelector(".theme-toggle-label");
+      if (icon) icon.textContent = ICONS[mode];
+      if (label) label.textContent = LABELS[mode];
+      toggle.setAttribute("aria-label", `Theme: ${LABELS[mode]}`);
     }
   }
 
-  function toggleTheme() {
-    const currentTheme = getCurrentTheme();
-    const newTheme = currentTheme === "dark" ? "light" : "dark";
-    setStoredTheme(newTheme);
-    applyTheme(newTheme);
+  function cycleTheme() {
+    const next = ORDER[(ORDER.indexOf(getMode()) + 1) % ORDER.length];
+    setMode(next);
+    apply(next);
   }
 
-  // Watch for system theme changes
-  const mediaQuery = window.matchMedia?.("(prefers-color-scheme: dark)");
-  mediaQuery?.addEventListener("change", (e) => {
-    if (!getStoredTheme()) {
-      applyTheme(e.matches ? "dark" : "light");
-    }
-  });
+  // Re-resolve when the OS theme changes while we're following it
+  window.matchMedia?.("(prefers-color-scheme: dark)").addEventListener(
+    "change",
+    () => {
+      if (getMode() === "auto") apply("auto");
+    },
+  );
 
-  // Theme toggle click handler
   document.addEventListener("click", (e) => {
     if (e.target.closest(".theme-toggle")) {
       e.preventDefault();
-      toggleTheme();
+      cycleTheme();
     }
   });
 
-  // Initialize theme
-  applyTheme(getCurrentTheme());
-  window.toggleTheme = toggleTheme;
+  apply(getMode());
+  window.cycleTheme = cycleTheme;
 })();
 
 // Click-to-copy functionality for command inputs


### PR DESCRIPTION
## Summary

Two independent improvements, one commit each.

### 1. `feat(site)`: three-way theme toggle
- Replaces the header dark-mode button with a three-way toggle in the nav row (right-aligned) that cycles **auto → light → dark → auto**.
- `auto` follows the OS via `prefers-color-scheme` and live-updates when the OS theme changes; `light`/`dark` are manual overrides.
- The anti-FOUC inline script in `_head` now resolves `auto` (and legacy/empty stored values) to the system theme instead of writing `data-theme="auto"`.
- Storage key unchanged (`theme`); old `light`/`dark` values keep working, anything else means follow-OS.

### 2. `chore(lint)`: brew-free RuboCop linting
Run linting locally without installing Homebrew.
- Vendors homebrew-core's RuboCop config as `.rubocop_homebrew.yml` (pure standard cops — no `require:`, no brew-only cops, runs under plain `rubocop`).
- `.rubocop.yml` is a thin overlay that inherits it and fills the two gaps from brew's internal base config: restores the default `**/*.rb` include (upstream sets it to `**/*.rbi` only), pins `TargetRubyVersion` to the Gemfile floor (`3.0`), and replays the `Metrics` disable.
- Adds `rubocop` to the Gemfile and `make lint` / `lint-fix` / `lint-update-config` targets.

**Not a full `brew style` replica:** the `FormulaAudit/*`, `Cask/*`, `Homebrew/*` audit cops only exist inside brew, so CI's `brew test-bot --only-tap-syntax` remains the authority on those. This covers the generic style/layout layer + the hand-written `scripts/`.

## Verification
- `make lint` → **27 files inspected, no offenses detected** (whole repo already Homebrew-style).
- Theme toggle cycle verified: `auto → light → dark → auto`; JS parses (`node --check`).

_Note: `Gemfile.lock` is gitignored in this repo, so it's not included._