### PR TITLE
feat(site): three-way theme toggle following system preference

### DIFF
--- a/theme/_head.html.erb
+++ b/theme/_head.html.erb
@@ -17,7 +17,8 @@
       try {
         const stored = window.localStorage.getItem("theme");
         const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-        const theme = stored || (prefersDark ? "dark" : "light");
+        const mode = (stored === "light" || stored === "dark") ? stored : "auto";
+        const theme = mode === "auto" ? (prefersDark ? "dark" : "light") : mode;
         document.documentElement.classList.toggle("dark", theme === "dark");
         document.documentElement.classList.toggle("light", theme !== "dark");
         document.documentElement.setAttribute("data-theme", theme);

--- a/theme/_header.html.erb
+++ b/theme/_header.html.erb
@@ -4,12 +4,9 @@
   </nav>
 
   <div class="header flex flex-col gap-6 rounded-3xl border border-slate-200 bg-white/80 p-8 shadow-sm ring-1 ring-black/5 backdrop-blur dark:border-slate-700 dark:bg-slate-900/80 dark:ring-white/10">
-    <div class="flex items-start justify-between gap-4">
-      <div class="space-y-2">
-        <h1 class="text-3xl font-bold tracking-tight md:text-4xl"><%= h(tap_name) %></h1>
-        <p class="max-w-3xl text-base text-slate-600 dark:text-slate-300"><%= h(description) %></p>
-      </div>
-      <button class="theme-toggle inline-flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full border border-slate-300 bg-white/80 text-xl text-slate-600 shadow-sm transition hover:bg-slate-100 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:border-slate-600 dark:bg-slate-900/70 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white" aria-label="Toggle dark mode" tabindex="0">🌙</button>
+    <div class="space-y-2">
+      <h1 class="text-3xl font-bold tracking-tight md:text-4xl"><%= h(tap_name) %></h1>
+      <p class="max-w-3xl text-base text-slate-600 dark:text-slate-300"><%= h(description) %></p>
     </div>
   </div>
 </header>

--- a/theme/_nav.html.erb
+++ b/theme/_nav.html.erb
@@ -10,4 +10,8 @@ end %>
   <% formulae_classes = [nav_base, (active_tab == :formulae ? nav_active : nil)].compact.join(' ') %>
   <a href="<%= h(href.call('index.html')) %>" class="<%= home_classes %>">Home</a>
   <a href="<%= h(href.call('formulae.html')) %>" class="<%= formulae_classes %>">All Formulae</a>
+  <button class="theme-toggle ml-auto inline-flex h-9 items-center gap-2 rounded-full border border-slate-300 bg-white/80 px-3 text-slate-600 shadow-sm transition hover:bg-slate-100 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:border-slate-600 dark:bg-slate-900/70 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white" aria-label="Theme: Auto" tabindex="0">
+    <span class="theme-toggle-icon" aria-hidden="true">🌗</span>
+    <span class="theme-toggle-label">Auto</span>
+  </button>
 </nav>

--- a/theme/main.js
+++ b/theme/main.js
@@ -1,71 +1,75 @@
-// Dark mode toggle functionality
+// Theme toggle: cycles auto -> light -> dark -> auto. Auto follows the OS.
 (() => {
   const STORAGE_KEY = "theme";
+  const ORDER = ["auto", "light", "dark"];
+  const ICONS = { auto: "🌗", light: "☀️", dark: "🌙" };
+  const LABELS = { auto: "Auto", light: "Light", dark: "Dark" };
 
-  function getStoredTheme() {
+  function getMode() {
+    let mode = null;
     try {
-      return localStorage.getItem(STORAGE_KEY);
+      mode = localStorage.getItem(STORAGE_KEY);
     } catch {
-      return null;
+      // Ignore storage failures
     }
+    return ORDER.includes(mode) ? mode : "auto";
   }
 
-  function setStoredTheme(theme) {
+  function setMode(mode) {
     try {
-      localStorage.setItem(STORAGE_KEY, theme);
+      localStorage.setItem(STORAGE_KEY, mode);
     } catch {
       // Ignore storage failures
     }
   }
 
-  function getSystemTheme() {
+  function resolve(mode) {
+    if (mode !== "auto") return mode;
     return window.matchMedia?.("(prefers-color-scheme: dark)").matches
       ? "dark"
       : "light";
   }
 
-  function getCurrentTheme() {
-    return getStoredTheme() || getSystemTheme() || "light";
-  }
+  function apply(mode) {
+    const theme = resolve(mode);
+    const root = document.documentElement;
+    root.classList.toggle("dark", theme === "dark");
+    root.classList.toggle("light", theme !== "dark");
+    root.setAttribute("data-theme", theme);
 
-  function applyTheme(theme) {
-    document.documentElement.classList.toggle("dark", theme === "dark");
     const toggle = document.querySelector(".theme-toggle");
     if (toggle) {
-      toggle.innerHTML = theme === "dark" ? "☀️" : "🌙";
-      toggle.setAttribute(
-        "aria-label",
-        theme === "dark" ? "Switch to light mode" : "Switch to dark mode",
-      );
+      const icon = toggle.querySelector(".theme-toggle-icon");
+      const label = toggle.querySelector(".theme-toggle-label");
+      if (icon) icon.textContent = ICONS[mode];
+      if (label) label.textContent = LABELS[mode];
+      toggle.setAttribute("aria-label", `Theme: ${LABELS[mode]}`);
     }
   }
 
-  function toggleTheme() {
-    const currentTheme = getCurrentTheme();
-    const newTheme = currentTheme === "dark" ? "light" : "dark";
-    setStoredTheme(newTheme);
-    applyTheme(newTheme);
+  function cycleTheme() {
+    const next = ORDER[(ORDER.indexOf(getMode()) + 1) % ORDER.length];
+    setMode(next);
+    apply(next);
   }
 
-  // Watch for system theme changes
-  const mediaQuery = window.matchMedia?.("(prefers-color-scheme: dark)");
-  mediaQuery?.addEventListener("change", (e) => {
-    if (!getStoredTheme()) {
-      applyTheme(e.matches ? "dark" : "light");
-    }
-  });
+  // Re-resolve when the OS theme changes while we're following it
+  window.matchMedia?.("(prefers-color-scheme: dark)").addEventListener(
+    "change",
+    () => {
+      if (getMode() === "auto") apply("auto");
+    },
+  );
 
-  // Theme toggle click handler
   document.addEventListener("click", (e) => {
     if (e.target.closest(".theme-toggle")) {
       e.preventDefault();
-      toggleTheme();
+      cycleTheme();
     }
   });
 
-  // Initialize theme
-  applyTheme(getCurrentTheme());
-  window.toggleTheme = toggleTheme;
+  apply(getMode());
+  window.cycleTheme = cycleTheme;
 })();
 
 // Click-to-copy functionality for command inputs


### PR DESCRIPTION
## Summary

Replaces the header dark-mode button with a **three-way** toggle placed in the nav row (right-aligned), cycling **auto → light → dark → auto**.

- `auto` follows the OS via `prefers-color-scheme` and live-updates when the OS theme changes.
- `light` / `dark` are manual overrides.
- The anti-FOUC inline script in `_head` now resolves `auto` (and legacy/empty stored values) to the system theme instead of writing `data-theme="auto"`.
- Storage key unchanged (`theme`); old `light`/`dark` values keep working, anything else means follow-OS.

## Files
- `theme/_nav.html.erb` — toggle button (icon + label) added to the nav row, `ml-auto`
- `theme/_header.html.erb` — old round button removed; header card collapses to the title block
- `theme/main.js` — rewrote the IIFE as an auto/light/dark state machine
- `theme/_head.html.erb` — FOUC script resolves `auto` to the OS theme

## Verification
- Cycle order verified: `auto → light → dark → auto`
- `node --check theme/main.js` passes