### PR TITLE
chore(lint): brew-free RuboCop linting + tracked Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Ruby
-Gemfile.lock
 .bundle/
 vendor/bundle/
 .ruby-lsp/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,38 @@
+# Homebrew's own RuboCop config, vendored + a thin local overlay.
+#
+# .rubocop_homebrew.yml is copied verbatim from Homebrew/homebrew-core:
+#   curl -fsSL https://raw.githubusercontent.com/Homebrew/homebrew-core/main/.rubocop.yml \
+#     -o .rubocop_homebrew.yml
+# Re-run that to refresh it. It is pure standard-cop config (Layout/Lint/Naming/
+# Style), so it runs with plain `rubocop` — no brew required.
+#
+# NOT a full replica of `brew style`: that layers this on top of brew's internal
+# base config, which disables Metrics and loads the FormulaAudit/Cask/Homebrew
+# cops that only exist inside brew. CI (`brew test-bot --only-tap-syntax`) remains
+# the authority on the audit cops; the overlay below just replays the Metrics
+# disable so local lint is not stricter than CI.
+inherit_from: .rubocop_homebrew.yml
+
+inherit_mode:
+  merge:
+    - Exclude
+
+AllCops:
+  # Honor the Gemfile floor (ruby ">= 3.0.0"); the vendored file pins 4.0.
+  TargetRubyVersion: "3.0"
+  # The vendored config sets Include to ["**/*.rbi"] (it assumes brew's base
+  # config supplies the default **/*.rb). Restore it so our .rb files are linted.
+  Include:
+    - "**/*.rb"
+    - "Gemfile"
+  Exclude:
+    - "vendor/**/*"
+    - "site/**/*"
+    - "_site/**/*"
+    - "node_modules/**/*"
+
+# The vendored homebrew-core file configures no Metrics (that disable lives in
+# brew's internal base config). Replicate it so local lint is not stricter than
+# CI. Re-enable if you want tighter checks on scripts/.
+Metrics:
+  Enabled: false

--- a/.rubocop_homebrew.yml
+++ b/.rubocop_homebrew.yml
@@ -1,0 +1,244 @@
+# This file is synced from `Homebrew/brew` by the `.github` repository, do not modify it directly.
+---
+AllCops:
+  TargetRubyVersion: 4.0
+  NewCops: enable
+  Include:
+  - "**/*.rbi"
+  Exclude:
+  - Homebrew/sorbet/rbi/{annotations,dsl,gems}/**/*.rbi
+  - Homebrew/sorbet/rbi/parser*.rbi
+  - Homebrew/bin/*
+  - Homebrew/vendor/**/*
+  - Taps/*/*/vendor/**/*
+  - "**/.github/copilot-instructions.md"
+  - "**/vendor/**/*"
+  SuggestExtensions:
+    rubocop-minitest: false
+Layout/ArgumentAlignment:
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/Formula/**/*.rb"
+  - "**/Formula/**/*.rb"
+Layout/CaseIndentation:
+  EnforcedStyle: end
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: start_of_line
+Layout/HashAlignment:
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
+Layout/LeadingCommentSpace:
+  Exclude:
+  - Taps/*/*/cmd/*.rb
+Layout/LineLength:
+  Max: 118
+  AllowedPatterns:
+  - "#: "
+  - ' url "'
+  - ' mirror "'
+  - " plist_options "
+  - ' executable: "'
+  - ' font "'
+  - ' homepage "'
+  - ' name "'
+  - ' pkg "'
+  - ' pkgutil: "'
+  - "    sha256 cellar: "
+  - "    sha256  "
+  - "#{language}"
+  - "#{version."
+  - ' "/Library/Application Support/'
+  - "\"/Library/Caches/"
+  - "\"/Library/PreferencePanes/"
+  - ' "~/Library/Application Support/'
+  - "\"~/Library/Caches/"
+  - "\"~/Library/Containers"
+  - "\"~/Application Support"
+  - " was verified as official when first introduced to the cask"
+Layout/SpaceAroundOperators:
+  Enabled: false
+Layout/SpaceBeforeBrackets:
+  Exclude:
+  - "**/*_spec.rb"
+  - Taps/*/*/*.rb
+  - "/**/{Formula,Casks}/**/*.rb"
+  - "**/{Formula,Casks}/**/*.rb"
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+Lint/DuplicateBranch:
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/{Formula,Casks}/**/*.rb"
+  - "**/{Formula,Casks}/**/*.rb"
+Lint/ParenthesesAsGroupedExpression:
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/Formula/**/*.rb"
+  - "**/Formula/**/*.rb"
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: true
+Metrics:
+  Enabled: false
+Naming/BlockForwarding:
+  Enabled: false
+Naming/FileName:
+  Regex: !ruby/regexp /^[\w\@\-\+\.]+(\.rb)?$/
+Naming/HeredocDelimiterNaming:
+  ForbiddenDelimiters:
+  - END, EOD, EOF
+Naming/InclusiveLanguage:
+  CheckStrings: true
+  FlaggedTerms:
+    slave:
+      AllowedRegex:
+      - gitslave
+      - log_slave
+      - ssdb_slave
+      - var_slave
+      - patches/13_fix_scope_for_show_slave_status_data.patch
+Naming/MethodName:
+  AllowedPatterns:
+  - "\\A(fetch_)?HEAD\\?\\Z"
+Naming/MethodParameterName:
+  inherit_mode:
+    merge:
+    - AllowedNames
+Naming/PredicateMethod:
+  AllowBangMethods: true
+Naming/VariableNumber:
+  Enabled: false
+Style/AndOr:
+  EnforcedStyle: always
+Style/ArgumentsForwarding:
+  Enabled: false
+Style/ArrayIntersect:
+  Enabled: false
+Style/AutoResourceCleanup:
+  Enabled: true
+Style/BarePercentLiterals:
+  EnforcedStyle: percent_q
+Style/BlockDelimiters:
+  BracesRequiredMethods:
+  - sig
+Style/ClassAndModuleChildren:
+  Exclude:
+  - "**/*.rbi"
+Style/CollectionMethods:
+  Enabled: true
+Style/DisableCopsWithinSourceCodeDirective:
+  Enabled: true
+  Include:
+  - Taps/*/*/*.rb
+  - "/**/{Formula,Casks}/**/*.rb"
+  - "**/{Formula,Casks}/**/*.rb"
+Style/Documentation:
+  Exclude:
+  - Taps/**/*
+  - "/**/{Formula,Casks}/**/*.rb"
+  - "**/{Formula,Casks}/**/*.rb"
+  - "**/*.rbi"
+Style/EmptyMethod:
+  Exclude:
+  - "**/*.rbi"
+Style/FetchEnvVar:
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/Formula/**/*.rb"
+  - "**/Formula/**/*.rb"
+Style/OneClassPerFile:
+  Exclude:
+  - "**/*.rbi"
+  - Taps/*/*/*.rb
+  - "/**/Abstract/**/*.rb"
+  - "**/Abstract/**/*.rb"
+  - "/**/Formula/**/*.rb"
+  - "**/Formula/**/*.rb"
+  - "/**/developer/bin/*"
+  - "**/developer/bin/*"
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/{Formula,Casks}/**/*.rb"
+  - "**/{Formula,Casks}/**/*.rb"
+  - Homebrew/test/**/Casks/**/*.rb
+  - "**/*.rbi"
+  - "**/Brewfile"
+Style/GuardClause:
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/{Formula,Casks}/**/*.rb"
+  - "**/{Formula,Casks}/**/*.rb"
+Style/HashAsLastArrayItem:
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/Formula/**/*.rb"
+  - "**/Formula/**/*.rb"
+Style/InverseMethods:
+  InverseMethods:
+    :blank?: :present?
+Style/InvertibleUnlessCondition:
+  Enabled: true
+  InverseMethods:
+    :==: :!=
+    :zero?:
+    :blank?: :present?
+Style/ItBlockParameter:
+  EnforcedStyle: only_numbered_parameters
+Style/MutableConstant:
+  EnforcedStyle: strict
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_only
+Style/NumericLiterals:
+  MinDigits: 11
+  Strict: true
+Style/OpenStructUse:
+  Exclude:
+  - Taps/**/*
+Style/OptionalBooleanParameter:
+  AllowedMethods:
+  - respond_to?
+  - respond_to_missing?
+Style/RescueStandardError:
+  EnforcedStyle: implicit
+Style/ReturnNil:
+  Enabled: true
+Style/StderrPuts:
+  Enabled: false
+Style/StringConcatenation:
+  Exclude:
+  - Taps/*/*/*.rb
+  - "/**/{Formula,Casks}/**/*.rb"
+  - "**/{Formula,Casks}/**/*.rb"
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+Style/StringMethods:
+  Enabled: true
+Style/SuperWithArgsParentheses:
+  Enabled: false
+Style/SymbolArray:
+  EnforcedStyle: brackets
+Style/TernaryParentheses:
+  EnforcedStyle: require_parentheses_when_complex
+Style/TopLevelMethodDefinition:
+  Enabled: true
+  Exclude:
+  - Taps/**/*
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+Style/UnlessLogicalOperators:
+  Enabled: true
+  EnforcedStyle: forbid_logical_operators
+Style/WordArray:
+  MinSize: 4
+

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,6 @@ gem "terser", "~> 1.2"
 
 # dev dependencies
 group :development do
+  gem "rubocop", "~> 1.81", require: false
   gem "webrick", "~> 1.9"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,76 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.3)
+    cssminify2 (2.1.0)
+    execjs (2.10.1)
+    json (2.21.1)
+    language_server-protocol (3.17.0.6)
+    lint_roller (1.1.0)
+    parallel (2.1.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    regexp_parser (2.12.0)
+    rubocop (1.88.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
+    terser (1.2.8)
+      execjs (>= 0.3.0, < 3)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    webrick (1.9.2)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  cssminify2 (~> 2.0)
+  json (~> 2.7)
+  rubocop (~> 1.81)
+  terser (~> 1.2)
+  webrick (~> 1.9)
+
+CHECKSUMS
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  cssminify2 (2.1.0) sha256=406a0b95fdaab60132c6f1fbb47b4a30f9572d2ef523f806fb94a530d78c2bb1
+  execjs (2.10.1) sha256=abe0ae028467eb8e30c10814eb934d07876a691aae7e803d813b7ce5a75e73f1
+  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rubocop (1.88.2) sha256=8def251c90cd955feb4daa3edc0ab56893250c4ce90ef81e6c80c03f9a939bbf
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  terser (1.2.8) sha256=64931851d173bc5be0a90bd4570d751be5e83b2b063ccb750dbdc11a7b1d14db
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
+
+RUBY VERSION
+  ruby 4.0.5
+
+BUNDLED WITH
+  4.0.10

--- a/Makefile
+++ b/Makefile
@@ -197,9 +197,18 @@ tap-install: ## Install this tap locally for testing
 	@echo "🍺 Installing tap locally..."
 	@brew tap $$(pwd)
 
-lint: ## Lint all Ruby scripts
-	@echo "🔍 Linting Ruby scripts..."
-	@brew style --fix --reset-cache .
+lint: ## Lint Ruby (RuboCop, no brew needed). Formula audit still runs in CI via brew.
+	@echo "🔍 Linting Ruby with RuboCop..."
+	@bundle exec rubocop
+
+lint-fix: ## Auto-correct safe RuboCop offenses
+	@echo "🔧 Auto-correcting RuboCop offenses..."
+	@bundle exec rubocop -A
+
+lint-update-config: ## Refresh vendored Homebrew RuboCop config from homebrew-core
+	@echo "⬇️  Updating .rubocop_homebrew.yml from Homebrew/homebrew-core..."
+	@curl -fsSL https://raw.githubusercontent.com/Homebrew/homebrew-core/main/.rubocop.yml -o .rubocop_homebrew.yml
+	@echo "✅ Updated. Run 'make lint' to check for new offenses."
 
 formula-new: ## Create a new formula template (usage: make formula-new NAME=myformula)
 	@if [ -z "$(NAME)" ]; then \


### PR DESCRIPTION
## Summary

Run linting locally without installing Homebrew, and pin dependency versions for reproducible installs.

### `chore(lint)`: brew-free RuboCop
- Vendors homebrew-core's RuboCop config as `.rubocop_homebrew.yml` (pure standard cops — no `require:`, no brew-only cops, runs under plain `rubocop`).
- `.rubocop.yml` is a thin overlay inheriting it, filling the two gaps from brew's internal base config: restores the default `**/*.rb` include (upstream sets it to `**/*.rbi` only), pins `TargetRubyVersion` to the Gemfile floor (`3.0`), and replays the `Metrics` disable.
- Adds `rubocop` to the Gemfile and `make lint` / `lint-fix` / `lint-update-config` targets.

**Not a full `brew style` replica:** the `FormulaAudit/*`, `Cask/*`, `Homebrew/*` audit cops only exist inside brew, so CI's `brew test-bot --only-tap-syntax` remains the authority on those. This covers the generic style/layout layer + the hand-written `scripts/`.

### `chore(deps)`: track Gemfile.lock
Stops ignoring `Gemfile.lock` so dependency versions (including the new rubocop toolchain) are pinned and reproducible across machines and CI.

## Verification
- `make lint` → **27 files inspected, no offenses detected**
- `bundle check` → dependencies satisfied