### PR TITLE
fix(ci): publish the site only when its inputs change

### DIFF
--- a/.github/workflows/pages-build.yml
+++ b/.github/workflows/pages-build.yml
@@ -3,11 +3,20 @@ name: Build and Deploy Documentation
 on:
   push:
     branches: [main]
+    # Explicit on purpose: only files the site build actually reads. Do not widen
+    # back to "scripts/**" (sync/serve/test scripts never touch the site) or add
+    # "docs/**" (gitignored build output plus plan docs). Adding Gemfile.lock or
+    # the workflow file makes every Renovate bump republish for nothing.
+    # No brace expansion here — GitHub path filters do not support "{a,b}".
     paths:
       - "Formula/**"
-      - "docs/**"
-      - "scripts/**"
       - "theme/**"
+      - "scripts/build_site.rb"
+      - "scripts/parse_formulas.rb"
+      - "scripts/asset_processor.rb"
+      - "scripts/array_extensions.rb"
+      - "scripts/string_extensions.rb"
+      - "scripts/time_formatter.rb"
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
Narrows the `pages-build.yml` push trigger to the files the build actually reads.

## Why

The existing filter listed `docs/**` and all of `scripts/**`. Neither is right:

- `docs/**` is gitignored build output (`.gitignore` lines 8-12). The only tracked files under it are `docs/plans/*.md`, which the build never opens.
- Half of `scripts/**` is never loaded by the site build: `sync_formulae.rb`, `test_sync_formulae.rb`, `serve.rb`, `file_watcher.rb`, `make.rb`.

## What the build actually reads

Traced through `make build` → `parse_formulas.rb` → `build_site.rb`:

| Input | Why |
| --- | --- |
| `Formula/**` | globbed by `parse_formulas.rb:51` |
| `theme/**` | ERB templates, `style.css`, `main.js`, fonts (`asset_processor.rb:60`) |
| `scripts/build_site.rb` | renders every page |
| `scripts/parse_formulas.rb` | produces `docs/_data/formulae.json` |
| `scripts/asset_processor.rb` | minifies CSS/JS, copies fonts |
| `scripts/array_extensions.rb` | required by `build_site.rb:11` |
| `scripts/string_extensions.rb` | required by `build_site.rb:12`, `parse_formulas.rb:8` |
| `scripts/time_formatter.rb` | required by `build_site.rb:13`, renders footers |

## Deliberately excluded

`Gemfile.lock`, `.ruby-version`, `Makefile`, and this workflow file. Each is technically a build input, but each is also churned by Renovate — including them would republish on every dependency bump, which is the exact waste this narrows away. Replaying history, adding `Gemfile.lock` alone would have turned the RuboCop bump in 495906b into a deploy.

`workflow_dispatch` stays as the escape hatch if a needed deploy does not fire.

## Verification

Replayed all 72 commits on `main` through both filters: the old one deployed 14 times, this one 13, adding none. The single removed deploy is a7e987b, which published for three `docs/.gitkeep` files.

The win is small and honestly stated: this is preventive, closing the `docs/plans/**` and non-site-`scripts/**` trapdoors before they fire, not a fix for ongoing waste.

## Note

GitHub path filters do not support brace expansion, so the two `*_extensions.rb` entries are listed separately rather than as `{array,string}_extensions.rb`.
