### PR TITLE
fix(sync): generate formulae inside the validation window

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -8,6 +8,21 @@ description: >-
   share a bin and collide during a single test-bot install run, and each
   formula pins its sha256 from GitHub's release API.
 
+inputs:
+  sync-formulae:
+    description: >-
+      Regenerate Formula/ from upstream releases before the syntax check, so
+      test-bot validates the generated formulae. Must happen here rather than in
+      the calling job: `Homebrew/actions/setup-homebrew` symlinks the tap to
+      $GITHUB_WORKSPACE and re-clones it at origin/main, discarding anything the
+      job wrote beforehand -- including generated formulae and local commits.
+      A fixed command rather than a caller-supplied one, to keep untrusted text
+      out of `run:`.
+    default: "false"
+  gh-token:
+    description: Token for the `gh` calls in sync_formulae.rb. Required when sync-formulae is true.
+    default: ""
+
 runs:
   using: composite
   steps:
@@ -58,6 +73,15 @@ runs:
     - name: Run brew test-bot (setup)
       shell: bash
       run: brew test-bot --only-setup
+
+    # After cleanup (which runs `git clean -ff -dx` on the tap) and before the
+    # syntax check, so the generated formulae are what gets validated.
+    - name: Generate formulae from latest releases
+      if: inputs.sync-formulae == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+      run: ruby scripts/sync_formulae.rb
 
     - name: Run brew test-bot (tap syntax)
       shell: bash

--- a/.github/workflows/sync-formulae.yml
+++ b/.github/workflows/sync-formulae.yml
@@ -27,13 +27,20 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
-
-      - name: Generate formulae from latest releases
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: ruby scripts/sync_formulae.rb
+      # Generation happens *inside* this action, between test-bot's cleanup and
+      # its syntax check. It cannot happen in an earlier step of this job:
+      # `Homebrew/actions/setup-homebrew` symlinks the tap into
+      # $GITHUB_WORKSPACE and re-clones it at origin/main, which discards both
+      # the generated formulae and any branch committed before it. That is what
+      # made this job fail with "src refspec sync/formulae does not match any"
+      # while test-bot silently validated main's formulae instead of the new
+      # ones. If this fails the job fails and no PR is opened.
+      # Ruby and bundler come from the action; no separate setup-ruby needed.
+      - name: Generate and validate formulae
+        uses: ./.github/actions/ci
+        with:
+          sync-formulae: "true"
+          gh-token: ${{ github.token }}
 
       - name: Detect changes
         id: diff
@@ -56,13 +63,6 @@ jobs:
           # -B keeps the already-staged changes on the new branch.
           git checkout -B sync/formulae
           git commit -m "chore(formulae): sync from upstream releases"
-
-      # Validate the freshly generated formulae in-job (via the shared composite
-      # action: brew style + audit + loadability). If this fails the job fails
-      # and no PR is opened.
-      - name: Validate generated formulae
-        if: steps.diff.outputs.changed == 'true'
-        uses: ./.github/actions/ci
 
       - name: Push branch and open or update PR
         if: steps.diff.outputs.changed == 'true'


### PR DESCRIPTION
Fixes the daily formula sync, which has failed every scheduled run since 2026-07-25 and has never once opened a PR.

## Symptom

```
error: src refspec sync/formulae does not match any
error: failed to push some refs to 'https://github.com/ivuorinen/homebrew-tap'
```

## Cause

`Homebrew/actions/setup-homebrew` symlinks the tap into `$GITHUB_WORKSPACE` and then **re-clones that workspace at `origin/main`**. The job log shows the same fetch-and-checkout sequence twice — once from `actions/checkout`, then again from `setup-homebrew`:

```
 99  actions/checkout: fetch +refs/heads/*:refs/remotes/origin/*
101   * [new branch]      main       -> origin/main
113   git checkout --progress --force -B main refs/remotes/origin/main
114  Switched to a new branch 'main'
...
244  Switched to a new branch 'sync/formulae'
260  [sync/formulae e74d334] chore(formulae): sync from upstream releases   ← 15 files
...
497  '/home/linuxbrew/.../Taps/ivuorinen/homebrew-tap' -> '/home/runner/work/homebrew-tap/homebrew-tap'
501   * [new branch]      main       -> origin/main      ← "new" again ⇒ .git was wiped
504  Switched to a new branch 'main'
...
739  error: src refspec sync/formulae does not match any
```

`origin/main` being reported as a **new** branch the second time proves the workspace `.git` was destroyed and rebuilt. The `sync/formulae` branch and commit `e74d334`, created earlier in the same job, do not survive it.

## The second, quieter bug

The same re-clone reverted the 15 generated formulae, so `brew test-bot --only-tap-syntax` was validating **`main`'s** formulae rather than the new ones. The in-job validation was a no-op, and the PR body's "Validated in-job by `brew test-bot`" claim was false.

## Why not just drop the in-job validation

PRs opened with `GITHUB_TOKEN` do not trigger `pull_request` workflows. `gh run list` confirms `ci.yml` has never run against `sync/formulae` and would not start. Sync PRs would ship entirely unvalidated.

## Fix

Move generation into `.github/actions/ci` behind a `sync-formulae` flag, placed after test-bot's cleanup (which runs `git clean -ff -dx`) and before its syntax check. Nothing re-clones the workspace after that point, so the branch survives and the formulae under test are the generated ones.

New step order in the sync job: checkout → generate + validate → detect changes → commit → push + PR.

`ci.yml` passes no inputs and is unaffected — the flag defaults to `false`.

The flag runs a fixed command rather than caller-supplied shell: `run: ${{ inputs.<string> }}` would interpolate caller text into a shell, which is the injection pattern actionlint and zizmor flag. With one caller and one command, a boolean is both safer and smaller.

## Trade-off

Validation now runs on every scheduled run, including no-change days — roughly two extra minutes daily. Unavoidable: whether anything changed cannot be known until after generating, and generating must happen inside the validation window.

## Verification

- Asserted programmatically: generation sits between cleanup and syntax check; `ci.yml` opts out via the default; no `git` command runs before the re-clone; `run:` interpolates no caller input.
- `pre-commit run` passes on both files.
- `ruby scripts/test_sync_formulae.rb` → `ALL PASS`.
- `actionlint` was not available locally, so the workflows are YAML-parsed and prettier-formatted but **not** lint-checked.
- **Not exercised against the real runner.** The reasoning rests on the job log; `setup-homebrew`'s behaviour under the new ordering cannot be reproduced locally. Worth a manual `gh workflow run sync-formulae.yml` before trusting the next scheduled run.
