### PR TITLE
fix(formulae): drop the redundant explicit version

### DIFF
--- a/Formula/a/a.rb
+++ b/Formula/a/a.rb
@@ -4,7 +4,6 @@
 class A < Formula
   desc "Encrypt and decrypt files with your SSH keys using the age format"
   homepage "https://github.com/ivuorinen/a"
-  version "1.0.0"
   license "MIT"
 
   on_macos do

--- a/Formula/a/a@1.0.0.rb
+++ b/Formula/a/a@1.0.0.rb
@@ -4,7 +4,6 @@
 class AAT100 < Formula
   desc "Encrypt and decrypt files with your SSH keys using the age format"
   homepage "https://github.com/ivuorinen/a"
-  version "1.0.0"
   license "MIT"
   keg_only :versioned_formula
 

--- a/Formula/g/gh-action-readme.rb
+++ b/Formula/g/gh-action-readme.rb
@@ -4,7 +4,6 @@
 class GhActionReadme < Formula
   desc "Generate documentation for GitHub Actions with themes and multiple formats"
   homepage "https://github.com/ivuorinen/gh-action-readme"
-  version "1.1.0"
   license "MIT"
 
   on_macos do

--- a/Formula/g/gh-action-readme@0.3.0.rb
+++ b/Formula/g/gh-action-readme@0.3.0.rb
@@ -4,7 +4,6 @@
 class GhActionReadmeAT030 < Formula
   desc "Generate documentation for GitHub Actions with themes and multiple formats"
   homepage "https://github.com/ivuorinen/gh-action-readme"
-  version "0.3.0"
   license "MIT"
   keg_only :versioned_formula
 

--- a/Formula/g/gh-action-readme@0.3.1.rb
+++ b/Formula/g/gh-action-readme@0.3.1.rb
@@ -4,7 +4,6 @@
 class GhActionReadmeAT031 < Formula
   desc "Generate documentation for GitHub Actions with themes and multiple formats"
   homepage "https://github.com/ivuorinen/gh-action-readme"
-  version "0.3.1"
   license "MIT"
   keg_only :versioned_formula
 

--- a/Formula/g/gh-action-readme@1.0.0.rb
+++ b/Formula/g/gh-action-readme@1.0.0.rb
@@ -4,7 +4,6 @@
 class GhActionReadmeAT100 < Formula
   desc "Generate documentation for GitHub Actions with themes and multiple formats"
   homepage "https://github.com/ivuorinen/gh-action-readme"
-  version "1.0.0"
   license "MIT"
   keg_only :versioned_formula
 

--- a/Formula/g/gh-action-readme@1.1.0.rb
+++ b/Formula/g/gh-action-readme@1.1.0.rb
@@ -4,7 +4,6 @@
 class GhActionReadmeAT110 < Formula
   desc "Generate documentation for GitHub Actions with themes and multiple formats"
   homepage "https://github.com/ivuorinen/gh-action-readme"
-  version "1.1.0"
   license "MIT"
   keg_only :versioned_formula
 

--- a/Formula/g/gh-calver.rb
+++ b/Formula/g/gh-calver.rb
@@ -4,7 +4,6 @@
 class GhCalver < Formula
   desc "GitHub CLI calver command"
   homepage "https://github.com/ivuorinen/gh-calver"
-  version "2026.03.4"
   license "MIT"
 
   on_macos do

--- a/Formula/g/gh-calver@0.1.0.rb
+++ b/Formula/g/gh-calver@0.1.0.rb
@@ -4,7 +4,6 @@
 class GhCalverAT010 < Formula
   desc "GitHub CLI calver command"
   homepage "https://github.com/ivuorinen/gh-calver"
-  version "0.1.0"
   license "MIT"
   keg_only :versioned_formula
 

--- a/Formula/g/gh-calver@2026.03.0.rb
+++ b/Formula/g/gh-calver@2026.03.0.rb
@@ -4,7 +4,6 @@
 class GhCalverAT2026030 < Formula
   desc "GitHub CLI calver command"
   homepage "https://github.com/ivuorinen/gh-calver"
-  version "2026.03.0"
   license "MIT"
   keg_only :versioned_formula
 

--- a/Formula/g/gh-calver@2026.03.1.rb
+++ b/Formula/g/gh-calver@2026.03.1.rb
@@ -4,7 +4,6 @@
 class GhCalverAT2026031 < Formula
   desc "GitHub CLI calver command"
   homepage "https://github.com/ivuorinen/gh-calver"
-  version "2026.03.1"
   license "MIT"
   keg_only :versioned_formula
 

--- a/Formula/g/gh-calver@2026.03.2.rb
+++ b/Formula/g/gh-calver@2026.03.2.rb
@@ -4,7 +4,6 @@
 class GhCalverAT2026032 < Formula
   desc "GitHub CLI calver command"
   homepage "https://github.com/ivuorinen/gh-calver"
-  version "2026.03.2"
   license "MIT"
   keg_only :versioned_formula
 

--- a/Formula/g/gh-calver@2026.03.4.rb
+++ b/Formula/g/gh-calver@2026.03.4.rb
@@ -4,7 +4,6 @@
 class GhCalverAT2026034 < Formula
   desc "GitHub CLI calver command"
   homepage "https://github.com/ivuorinen/gh-calver"
-  version "2026.03.4"
   license "MIT"
   keg_only :versioned_formula
 

--- a/Formula/g/gh-history.rb
+++ b/Formula/g/gh-history.rb
@@ -4,7 +4,6 @@
 class GhHistory < Formula
   desc "GitHub CLI history command"
   homepage "https://github.com/ivuorinen/gh-history"
-  version "2026.03.0"
   license "MIT"
 
   on_macos do

--- a/Formula/g/gh-history@2026.03.0.rb
+++ b/Formula/g/gh-history@2026.03.0.rb
@@ -4,7 +4,6 @@
 class GhHistoryAT2026030 < Formula
   desc "GitHub CLI history command"
   homepage "https://github.com/ivuorinen/gh-history"
-  version "2026.03.0"
   license "MIT"
   keg_only :versioned_formula
 

--- a/scripts/sync_formulae.rb
+++ b/scripts/sync_formulae.rb
@@ -102,7 +102,10 @@ module SyncFormulae
     lines << "class #{meta[:class]} < Formula"
     lines << %Q(  desc "#{meta[:desc]}")
     lines << %Q(  homepage "#{meta[:homepage]}")
-    lines << %Q(  version "#{meta[:version]}")
+    # No explicit `version`: every asset URL carries the tag, so Homebrew scans
+    # the version off it and `brew audit` rejects restating it ("Stable:
+    # `version X` is redundant with version scanned from URL"). The docs site
+    # recovers it the same way, via parse_formulas.rb's URL fallback.
     lines << %Q(  license "#{meta[:license]}") if meta[:license]
     lines << "  keg_only :versioned_formula" if meta[:keg_only]
     lines << ""

--- a/scripts/test_sync_formulae.rb
+++ b/scripts/test_sync_formulae.rb
@@ -159,14 +159,27 @@ class TestSyncFormulae
         desc: "GitHub CLI calver command", homepage: "https://github.com/ivuorinen/gh-calver",
         version: "2026.03.4", released_at: "2026-03-04T12:00:00Z", license: "MIT", bin: "gh-calver",
         test: 'system bin/"gh-calver", "--help"', archive: false,
-        platforms: [{ os: "macos", arch: "arm", url: "https://x/gh-calver_darwin-arm64", sha256: "a" * 64 }]
+        # Real release-asset URL shape: the tag in the path is now the only
+        # carrier of the version, so the fixture must not elide it.
+        platforms: [{ os: "macos", arch: "arm",
+                      url: "https://github.com/ivuorinen/gh-calver/releases/download/2026.03.4/gh-calver_darwin-arm64",
+                      sha256: "a" * 64 }]
       }
     end
   end
 
   def check_formula_body
     body = SyncFormulae.formula_body(base_meta(keg_only: false, formula_name: "gh-calver", klass: "GhCalver"))
-    check("formula_body has explicit version (docs parser needs it)") { body.include?("version \"2026.03.4\"") }
+    # `brew audit` rejects an explicit version when the URL already yields it.
+    check("formula_body omits explicit version (brew audit rejects it)") do
+      body.match?(/^\s*version\s/).!
+    end
+    # ...so the version must stay recoverable from the URL, which is how both
+    # Homebrew and parse_formulas.rb#extract_version get it now.
+    check("version is recoverable from the asset URL") do
+      url = body[/^\s*url "([^"]+)"/, 1]
+      url && url.match(/v?(\d+(?:\.\d+)+)/)&.[](1) == "2026.03.4"
+    end
     check("formula_body raw install uses stable.url basename") { body.include?("File.basename(stable.url)") }
     check("formula_body nests on_macos/on_arm") { body.include?("on_macos do") && body.include?("on_arm do") }
     check("formula_body omits keg_only when not versioned") { body["keg_only"].nil? }


### PR DESCRIPTION
Unblocks CI, which is currently red on `main` and on every open PR.

## Symptom

```
Error: 1 failed step!
brew audit --except=installed --tap=ivuorinen/tap
##[error]15 problems in 15 formulae detected.
##[error]Stable: `version 1.0.0` is redundant with version scanned from URL
... one per formula, all 15
```

## This is upstream, not a regression here

Re-running `ci.yml` at the **unchanged** commit `932105c` — which was green on 2026-07-28 — now fails identically on both runners (60 matching error lines). Same code, same SHA, different result. `Homebrew/actions/setup-homebrew` pulls the latest `Homebrew/brew` on every run, and the audit rule tightened in between.

## Fix

Every asset URL already carries the tag:

```
https://github.com/ivuorinen/gh-calver/releases/download/2026.03.4/gh-calver_darwin-arm64
```

Homebrew scans the version off that, so restating it in a `version` line is exactly what the audit objects to. This stops `formula_body` emitting it and strips it from the 15 generated formulae.

## The docs site is not affected

The unit suite asserted the explicit version was required — *"formula_body has explicit version (docs parser needs it)"*. That was worth checking rather than trusting: `parse_formulas.rb#extract_version` (lines 99-109) already falls back to scanning the URL when no explicit version is present.

Proven rather than assumed — `formulae.json` version map, captured before and after the change:

```
formulae: 15 -> 15
version diffs: NONE - all 15 versions identical
```

## Test changes

- The check asserting an explicit version is **inverted** to assert its absence, since `brew audit` now rejects it.
- A new check asserts the version stays recoverable from the URL — that is the real invariant now, and nothing was covering it.
- The fixture URL was `https://x/gh-calver_darwin-arm64`, which carries no version at all. It is now a realistic release-asset URL, because the tag in the path is the only carrier left. The old fixture would have passed while the real thing broke.

## Verification

- `ruby scripts/test_sync_formulae.rb` → `ALL PASS`
- `bundle exec rubocop` → 27 files, no offenses
- `formulae.json` diff → no change to any of the 15 versions
- `brew audit` itself can only run in CI — `brew` is not installed locally, so the pre-commit `Brew Style` hook was skipped. **This PR's own `Test bot` run is the first real check of the fix.**

## Ordering

This should land before #65 and #66; both are mergeable but red for this reason, and both will go green once this is on `main`. It also unblocks the daily sync independently of #66 — the sync would currently fail validation even with that PR's ordering fix in place.
